### PR TITLE
Active storage transaction fix

### DIFF
--- a/app/jobs/process_order_job.rb
+++ b/app/jobs/process_order_job.rb
@@ -7,8 +7,6 @@ class ProcessOrderJob < ApplicationJob
   def perform(order_id)
     @order = Order.find(order_id)
     update_order
-    generate_invoice
-    generate_certificates
     send_order_confirmation
     send_gift_certificates
     # Not delivery to do if only trees in the order
@@ -20,26 +18,6 @@ class ProcessOrderJob < ApplicationJob
   def update_order
     @order.update(payment_date: Time.zone.now, total_price: @order.ttc_price_all_included,
                   delivery_fees: @order.current_delivery_fees)
-  end
-
-  def generate_invoice
-    pdf_html = ActionController::Base.new.render_to_string(
-      template: 'invoices/new',
-      locals: { '@order': @order, '@delivery_address': @order.delivery_address,
-        '@billing_address': @order.billing_address },
-      layout: 'layouts/pdf'
-    )
-    pdf = WickedPdf.new.pdf_from_string(pdf_html)
-    @order.invoice.attach(io: StringIO.new(pdf), filename: "invoice##{@order.id}.pdf",
-                          content_type: 'application/pdf')
-  end
-
-  def generate_certificates
-    @order.line_items.each do |line_item|
-      next if line_item.tree_plantation.nil?
-
-      line_item.generate_certificate
-    end
   end
 
   def send_order_confirmation

--- a/app/mailers/client_mailer.rb
+++ b/app/mailers/client_mailer.rb
@@ -11,10 +11,15 @@ class ClientMailer < ApplicationMailer
 
   def order_confirmation
     @order = params[:order]
-    attachments['invoice.pdf'] = @order.invoice.download
-    @order.line_items.certificated.each do |line_item|
-      attachments["certificate##{line_item.id}.pdf"] = line_item.certificate.download
+
+    invoice = @order.generate_invoice
+    attachments['invoice.pdf'] = invoice
+
+    certificate_files = @order.generate_certificates
+    certificate_files.each do |line_item_id, certificate_file|
+      attachments["certificate##{line_item_id}.pdf"] = certificate_file
     end
+
     mail to: @order.delivery_address_email
   end
 

--- a/app/mailers/recipient_mailer.rb
+++ b/app/mailers/recipient_mailer.rb
@@ -3,7 +3,13 @@
 class RecipientMailer < ApplicationMailer
   def gift_certificate
     @line_item = params[:line_item]
-    attachments['certificate.pdf'] = @line_item.certificate.download
+    certificate =
+      begin
+        @line_item.certificate.download
+      rescue ActiveStorage::FileNotFoundError
+        @line_item.generate_certificate
+      end
+    attachments['certificate.pdf'] = certificate
     mail to: @line_item.delivery_email
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -146,8 +146,10 @@ class LineItem < ApplicationRecord
     )
     pdf = WickedPdf.new.pdf_from_string(pdf_html, orientation: 'Landscape')
     certificate.attach(io: StringIO.new(pdf),
-                                filename: "certificate##{id}.pdf",
-                                content_type: 'application/pdf')
+                       filename: "certificate##{id}.pdf",
+                       content_type: 'application/pdf')
+
+    pdf
   end
 
   def shipping_weight
@@ -182,7 +184,7 @@ class LineItem < ApplicationRecord
   end
 
   def decrement_stock_quantities
-    product_sku.decrement(:quantity, added_quantity)     unless tree_or_personalized?
+    product_sku.decrement(:quantity, added_quantity)      unless tree_or_personalized?
     tree_plantation&.decrement(:quantity, added_quantity) if tree_or_personalized?
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -288,6 +288,34 @@ class Order < ApplicationRecord
     delivery_address&.email.presence || client_email
   end
 
+  def generate_invoice
+    pdf_html = ActionController::Base.new.render_to_string(
+      template: 'invoices/new',
+      locals: { '@order': self, '@delivery_address': delivery_address,
+        '@billing_address': billing_address },
+      layout: 'layouts/pdf'
+    )
+    pdf = WickedPdf.new.pdf_from_string(pdf_html)
+    invoice.attach(
+      io: StringIO.new(pdf),
+      filename: "invoice##{id}.pdf",
+      content_type: 'application/pdf'
+    )
+
+    pdf
+  end
+
+  def generate_certificates
+    certificate_files = {}
+    line_items.each do |line_item|
+      next if line_item.tree_plantation.nil?
+
+      certificate_files[line_item.id] = line_item.generate_certificate
+    end
+
+    certificate_files
+  end
+
   private
 
   def process_order

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Use a real queuing backend for Active Job (and separate queues per environment)
-  config.active_job.queue_adapter = :sidekiq
+  config.active_job.queue_adapter = :inline
 
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
When using the `config.active_job.queue_adapter = :inline` ActiveStorage attachments were not ready to be downloaded from inside the same transaction that is not yet commited. See this issue: rails/rails#36994

So to fix this issue we now are generating all the files outside of the ProcessOrderJob transaction. This is not a problem when we use sidekiq as the queue backend because it will run in a background job outside of the original transaction.